### PR TITLE
Improve zh_CN translations

### DIFF
--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -12,16 +12,16 @@
     "message": "使用方法"
   },
   "explanation_intro": {
-    "message": "点击下方的按钮会生成一段代码，该代码必须保存在一个名为 “policies.json” 的文件里，位于 distribution 目录下。"
+    "message": "点击下方的按钮会生成一段代码。该代码需要保存在一个名为 “policies.json” 的文件里，放在 distribution 目录。"
   },
   "explanation_intro_linux": {
-    "message": "在 Firefox 安装目录创建一个名为 “distribution” 的文件夹，并将 “policies.json” 文件放在该文件夹下。"
+    "message": "在 Firefox 安装目录中创建一个名为 “distribution” 的文件夹，并将 “policies.json” 文件放到该文件夹。"
   },
   "explanation_intro_macos": {
-    "message": "在 Firefox.app/Contents/Resources/ 创建一个名为 “distribution” 的文件夹，并将 “policies.json” 文件放在该文件夹下。"
+    "message": "在 Firefox.app/Contents/Resources/ 中创建一个名为 “distribution” 的文件夹，并将 “policies.json” 文件放到该文件夹。"
   },
   "explanation_intro_windows": {
-    "message": "在 firefox.exe 文件所在的目录创建一个名为 “distribution” 的文件夹，并将 “policies.json” 文件放在该文件夹下。"
+    "message": "在 firefox.exe 文件所在的目录创建一个名为 “distribution” 的文件夹，并将 “policies.json” 文件放到该文件夹。"
   },
   "extension_description": {
     "message": "为 Firefox 生成企业策略。"
@@ -54,7 +54,7 @@
     "message": "取消"
   },
   "list_dialog_no_saved_configurations": {
-    "message": "尚未有任何配置保存。"
+    "message": "尚未保存任何配置。"
   },
   "list_dialog_window_title": {
     "message": "载入配置"
@@ -69,7 +69,7 @@
     "message": "保护首选项不被修改"
   },
   "mandatory_label": {
-    "message": "必需"
+    "message": "必填"
   },
   "policy_category_block_access": {
     "message": "阻止访问"
@@ -78,7 +78,7 @@
     "message": "禁用功能"
   },
   "policy_category_customization": {
-    "message": "自定义"
+    "message": "定制"
   },
   "policy_category_network": {
     "message": "网络"
@@ -111,7 +111,7 @@
     "message": "始终允许在非 FQDN 上使用 SPNEGO (Firefox 63++)"
   },
   "policy_description_Authentication_Delegated": {
-    "message": "Delegated"
+    "message": "委托（Delegated）"
   },
   "policy_description_Authentication_Delegated_URL": {
     "message": "URL"
@@ -135,7 +135,7 @@
     "message": "阻止访问浏览器配置页面 (about:config)"
   },
   "policy_description_BlockAboutProfiles": {
-    "message": "阻止访问内嵌的配置管理器 (about:profiles)"
+    "message": "阻止访问内嵌的配置文件管理器 (about:profiles)"
   },
   "policy_description_BlockAboutSupport": {
     "message": "阻止访问故障排除信息页面 (about:support)"
@@ -144,7 +144,7 @@
     "message": "创建默认的书签"
   },
   "policy_description_Bookmarks_Favicon": {
-    "message": "小图标"
+    "message": "网站图标（Favicon）"
   },
   "policy_description_Bookmarks_Folder": {
     "message": "文件夹"
@@ -165,13 +165,13 @@
     "message": "URL"
   },
   "policy_description_Certificates": {
-    "message": "读取来自 Windows 证书商店的证书（仅支持 Windows）"
+    "message": "读取 Windows 证书存储的证书（仅限 Windows）"
   },
   "policy_description_Certificates_ImportEnterpriseRoots_false": {
-    "message": "不读取来自 Windows 证书商店的证书"
+    "message": "不读取 Windows 证书存储的证书"
   },
   "policy_description_Certificates_ImportEnterpriseRoots_true": {
-    "message": "读取来自 Windows 证书商店的证书"
+    "message": "读取 Windows 证书存储的证书"
   },
   "policy_description_Cookies": {
     "message": "允许或阻止网站设置 Cookie"
@@ -222,25 +222,25 @@
     "message": "阻止 Firefox 进行更新"
   },
   "policy_description_DisableBuiltinPDFViewer": {
-    "message": "禁用内建的 PDF 阅读器 (pdf.js)"
+    "message": "禁用内置的 PDF 阅读器 (pdf.js)"
   },
   "policy_description_DisableDeveloperTools": {
-    "message": "禁用内建的开发者工具"
+    "message": "禁用内置的开发者工具"
   },
   "policy_description_DisableFeedbackCommands": {
-    "message": "禁用帮助菜单中的“提交反馈”和“举报诈骗网站”菜单项"
+    "message": "禁用“帮助”菜单中的“提交反馈”和“举报诈骗网站”菜单"
   },
   "policy_description_DisableFirefoxAccounts": {
     "message": "禁用基于 Firefox 账户的 Firefox 同步等服务"
   },
   "policy_description_DisableFirefoxScreenshots": {
-    "message": "禁用内建的截图工具（Firefox 截图）"
+    "message": "禁用内置的截图工具（Firefox Screenshots）"
   },
   "policy_description_DisableFirefoxStudies": {
     "message": "阻止 Firefox 安装并运行一些实验项目（SHIELD 实验）"
   },
   "policy_description_DisableForgetButton": {
-    "message": "禁用“抹去足迹”工具栏按钮，防止清除最近的浏览历史"
+    "message": "禁用“抹去足迹”工具栏按钮，阻止用它清除最近的浏览历史"
   },
   "policy_description_DisableFormHistory": {
     "message": "禁用表单和搜索栏历史"
@@ -255,7 +255,7 @@
     "message": "禁用隐私浏览模式"
   },
   "policy_description_DisableProfileImport": {
-    "message": "禁用我的足迹里的“从其他浏览器导入数据”菜单项"
+    "message": "禁用“我的足迹”里的“从其他浏览器导入数据”菜单"
   },
   "policy_description_DisableProfileRefresh": {
     "message": "禁用 about:support 页面中的“翻新 Firefox” 按钮"
@@ -264,7 +264,7 @@
     "message": "禁用 Firefox 安全模式（禁用所有附加组件并重开浏览器）"
   },
   "policy_description_DisableSecurityBypass": {
-    "message": "阻止特定安全警告被跳过"
+    "message": "阻止跳过特定的安全警告"
   },
   "policy_description_DisableSecurityBypass_InvalidCertificate": {
     "message": "阻止将已显示为无效的证书添加到例外列表"
@@ -291,13 +291,13 @@
     "message": "阻止"
   },
   "policy_description_DisableSetDesktopBackground": {
-    "message": "禁止将图片设为桌面背景"
+    "message": "禁用将图像设为桌面背景的功能"
   },
   "policy_description_DisableSystemAddonUpdate": {
     "message": "阻止 Firefox 安装和更新系统附加组件"
   },
   "policy_description_DisableTelemetry": {
-    "message": "阻止 Firefox 发送技术信息及交互数据到 Mozilla (telemetry)"
+    "message": "阻止 Firefox 发送技术信息和交互数据到 Mozilla （遥测）"
   },
   "policy_description_DisplayBookmarksToolbar": {
     "message": "默认显示书签工具栏"
@@ -306,7 +306,7 @@
     "message": "默认显示菜单栏"
   },
   "policy_description_DontCheckDefaultBrowser": {
-    "message": "启动时不检查 Firefox 是否是默认浏览器"
+    "message": "启动时不检查 Firefox 是否为默认浏览器"
   },
   "policy_description_EnableTrackingProtection": {
     "message": "启用或禁用跟踪保护"
@@ -318,22 +318,22 @@
     "message": "启用跟踪保护"
   },
   "policy_description_Extensions": {
-    "message": "安装、卸载或锁定扩展"
+    "message": "安装、卸载或锁定特定扩展"
   },
   "policy_description_Extensions_Install": {
-    "message": "在这里安装附加组件。你可以指定 URL 或路径。"
+    "message": "在这里设定安装附加组件。您可以指定 URL 或路径。"
   },
   "policy_description_Extensions_Install_URL_or_Path": {
     "message": "URL 或路径"
   },
   "policy_description_Extensions_Locked": {
-    "message": "被锁定的扩展将无法禁用或卸载。请指定扩展的 ID。"
+    "message": "被锁定的扩展不能被禁用或卸载。请指定扩展的 ID。"
   },
   "policy_description_Extensions_Locked_ID": {
     "message": "附加组件 ID"
   },
   "policy_description_Extensions_Uninstall": {
-    "message": "在这里卸载附加组件，请指定扩展的 ID。"
+    "message": "在这里设定卸载附加组件。请指定扩展的 ID。"
   },
   "policy_description_Extensions_Uninstall_ID": {
     "message": "附加组件 ID"
@@ -342,13 +342,13 @@
     "message": "允许或阻止使用 Flash 插件"
   },
   "policy_description_FlashPlugin_Allow": {
-    "message": "针对这些 URL 默认启用 Flash 插件，除非已完全禁用 Flash"
+    "message": "在这些 URL 下默认启用 Flash 插件，除非已完全禁用 Flash"
   },
   "policy_description_FlashPlugin_Allow_URL": {
     "message": "URL"
   },
   "policy_description_FlashPlugin_Block": {
-    "message": "阻止 Flash 插件使用在这些 URL"
+    "message": "阻止 Flash 插件在这些 URL 下使用"
   },
   "policy_description_FlashPlugin_Block_URL": {
     "message": "URL"
@@ -381,7 +381,7 @@
     "message": "允许网站安装附加组件"
   },
   "policy_description_InstallAddonsPermission_Allow": {
-    "message": "下面是允许安装扩展的网站，除非扩展安装的功能被禁用（已允许 addons.mozilla.org）"
+    "message": "下列是允许安装扩展的网站，除非扩展安装的功能被禁用（已允许 addons.mozilla.org）"
   },
   "policy_description_InstallAddonsPermission_Allow_URL": {
     "message": "URL"
@@ -393,7 +393,7 @@
     "message": "允许用户安装附加组件"
   },
   "policy_description_NoDefaultBookmarks": {
-    "message": "不创建默认的书签集，包括智能书签（最常访问的、最近的标签）。注意：该策略仅在配置文件夹首次使用之前就用过的情况下才有效"
+    "message": "不创建默认的书签集，包括智能书签（最常访问、最近的标签）。注意：该策略仅在配置文件首次启用时生效"
   },
   "policy_description_OfferToSaveLogins": {
     "message": "允许或禁止 Firefox 记住登录的账号和密码"
@@ -405,10 +405,10 @@
     "message": "记住登录的账号和密码"
   },
   "policy_description_OverrideFirstRunPage": {
-    "message": "允许覆盖首次运行时显示的页面。如果你想禁止显示，请设置为空白。"
+    "message": "允许覆盖首次运行时显示的页面。如果您想禁止显示，请将 URL 栏留空。"
   },
   "policy_description_OverridePostUpdatePage": {
-    "message": "覆盖浏览器更新完毕显示的“更新内容”页面。如果你想禁止显示该页面，请设置为空白。"
+    "message": "覆盖浏览器更新后显示的“新功能”（What's New）页面。如果您想禁止显示该页面，请将 URL 栏留空。"
   },
   "policy_description_Permissions": {
     "message": "配置位置、摄像头、麦克风和通知的权限"
@@ -417,73 +417,73 @@
     "message": "摄像头"
   },
   "policy_description_Permissions_Camera_Allow": {
-    "message": "允许下列 URL 操控"
+    "message": "允许下列 URL 访问"
   },
   "policy_description_Permissions_Camera_Allow_URL": {
     "message": "URL"
   },
   "policy_description_Permissions_Camera_Block": {
-    "message": "阻止下列 URL 操控"
+    "message": "阻止下列 URL 访问"
   },
   "policy_description_Permissions_Camera_Block_URL": {
     "message": "URL"
   },
   "policy_description_Permissions_Camera_BlockNewRequests": {
-    "message": "阻止新的请求操控你的摄像头"
+    "message": "阻止访问您的摄像头的新授权请求"
   },
   "policy_description_Permissions_Location": {
-    "message": "位置"
+    "message": "地理位置"
   },
   "policy_description_Permissions_Location_Allow": {
-    "message": "允许下列 URL 获知"
+    "message": "允许下列 URL 获取"
   },
   "policy_description_Permissions_Location_Allow_URL": {
     "message": "URL"
   },
   "policy_description_Permissions_Location_Block": {
-    "message": "阻止下列 URL 获知"
+    "message": "阻止下列 URL 获取"
   },
   "policy_description_Permissions_Location_Block_URL": {
     "message": "URL"
   },
   "policy_description_Permissions_Location_BlockNewRequests": {
-    "message": "阻止新的请求获知你的位置"
+    "message": "阻止获知您的位置的的新授权请求"
   },
   "policy_description_Permissions_Microphone": {
     "message": "麦克风"
   },
   "policy_description_Permissions_Microphone_Allow": {
-    "message": "允许下列 URL 操控"
+    "message": "允许下列 URL 访问"
   },
   "policy_description_Permissions_Microphone_Allow_URL": {
     "message": "URL"
   },
   "policy_description_Permissions_Microphone_Block": {
-    "message": "阻止下列 URL 操控"
+    "message": "阻止下列 URL 访问"
   },
   "policy_description_Permissions_Microphone_Block_URL": {
     "message": "URL"
   },
   "policy_description_Permissions_Microphone_BlockNewRequests": {
-    "message": "阻止新的请求操控你的麦克风"
+    "message": "阻止访问您的麦克风的新授权请求"
   },
   "policy_description_Permissions_Notifications": {
     "message": "通知"
   },
   "policy_description_Permissions_Notifications_Allow": {
-    "message": "允许下列 URL 传送通知"
+    "message": "允许下列 URL 发出通知"
   },
   "policy_description_Permissions_Notifications_Allow_URL": {
     "message": "URL"
   },
   "policy_description_Permissions_Notifications_Block": {
-    "message": "阻止下列 URL 传送通知"
+    "message": "阻止下列 URL 发出通知"
   },
   "policy_description_Permissions_Notifications_Block_URL": {
     "message": "URL"
   },
   "policy_description_Permissions_Notifications_BlockNewRequests": {
-    "message": "阻止新的请求向你传送通知"
+    "message": "阻止向您发送通知的新授权请求"
   },
   "policy_description_PopupBlocking": {
     "message": "允许或阻止显示弹出窗口"
@@ -501,10 +501,10 @@
     "message": "默认阻止弹出窗口"
   },
   "policy_description_Proxy": {
-    "message": "配置连接互联网的代理"
+    "message": "配置连接互联网的代理服务器"
   },
   "policy_description_Proxy_AutoConfigURL": {
-    "message": "自动代理配置的 URL"
+    "message": "自动代理配置（PAC）的 URL"
   },
   "policy_description_Proxy_AutoLogin": {
     "message": "提示身份验证"
@@ -567,7 +567,7 @@
     "message": "代理 DNS 查询"
   },
   "policy_description_SanitizeOnShutdown": {
-    "message": "关闭浏览器时清除所有数据"
+    "message": "关闭浏览器时清除所有浏览器数据"
   },
   "policy_description_SearchBar": {
     "message": "搜索栏合并或分开显示"
@@ -585,7 +585,7 @@
     "message": "添加更多搜索引擎"
   },
   "policy_description_SearchEngines_Add_Alias": {
-    "message": "用于调用搜索引擎的别名"
+    "message": "调用搜索引擎的别名（关键字）"
   },
   "policy_description_SearchEngines_Add_Description": {
     "message": "描述"
@@ -594,7 +594,7 @@
     "message": "图标 URL"
   },
   "policy_description_SearchEngines_Add_Method": {
-    "message": "请求的方法"
+    "message": "请求方法"
   },
   "policy_description_SearchEngines_Add_Method_GET": {
     "message": "GET"
@@ -606,16 +606,16 @@
     "message": "名称"
   },
   "policy_description_SearchEngines_Add_SuggestURLTemplate": {
-    "message": "用于搜索建议的 URL。请使用 {searchTerms} 作为搜索项的占位符"
+    "message": "搜索建议的 URL。使用 {searchTerms} 作为搜索关键词的占位符"
   },
   "policy_description_SearchEngines_Add_URL": {
-    "message": "用于搜索的 URL。请使用 {searchTerms} 作为搜索项的占位符"
+    "message": "搜索的 URL。使用 {searchTerms} 作为搜索关键词的占位符"
   },
   "policy_description_SearchEngines_Default": {
     "message": "默认搜索引擎的名称"
   },
   "policy_description_SearchEngines_PreventInstalls": {
-    "message": "阻止安装新的搜索引擎"
+    "message": "阻止安装新搜索引擎"
   },
   "policy_description_SearchEngines_PreventInstalls_false": {
     "message": "不阻止安装"
@@ -630,7 +630,7 @@
     "message": "名称"
   },
   "policy_description_WebsiteFilter": {
-    "message": "阻止访问特定网站。你可以使用 “<all_urls>” 屏蔽所有 URL。点击更多信息链接可以查看所有有效项，仅支持 HTTPS 和 HTTP 的 URL。"
+    "message": "阻止访问特定网站。您可以使用 “<all_urls>” 屏蔽所有 URL。点击更多信息链接可以查看所有有效项，仅支持 HTTPS 和 HTTP 的 URL。"
   },
   "policy_description_WebsiteFilter_Block": {
     "message": "屏蔽下列 URL"
@@ -654,7 +654,7 @@
     "message": "名称"
   },
   "save_dialog_window_title": {
-    "message": "保存配置Save Configuration"
+    "message": "保存配置"
   },
   "title_add_row": {
     "message": "新增行"


### PR DESCRIPTION
cc @fang5566.

`Rename zh-CN to zh_CN` because of https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Internationalization#Providing_localized_strings_in__locales.
Although Firefox accepts "zh-CN", but Chrome doesn't, it may be a norm.