### PR TITLE
Fixed typo in french locale

### DIFF
--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -204,10 +204,10 @@
     "message": "Activer ou désactiver le support de portail captif"
   },
   "policy_description_CaptivePortal_options_false": {
-    "message": "Désactiver support portail captif"
+    "message": "Désactiver le support de portail captif"
   },
   "policy_description_CaptivePortal_options_true": {
-    "message": "Désactiver support portail captif"
+    "message": "Activer le support de portail captif"
   },
   "policy_description_Certificates": {
     "message": "Configurer certificats"


### PR DESCRIPTION
The French locale has a typo in the captive portal setting.

Both options state that it disables the support, I corrected it and also rectified some grammatical errors