### PR TITLE
fix: invert updates_disabled mapping in ExtensionSettings policy

### DIFF
--- a/src/policies/firefox.json
+++ b/src/policies/firefox.json
@@ -752,7 +752,20 @@
             "name": "updates_disabled",
             "label": "policy_description_ExtensionSettings_updates_disabled",
             "schema": "enum",
-            "preset": "boolean_inverted_optional"
+            "options": [
+              {
+                "label": "enum_value_no_preference",
+                "value": null
+              },
+              {
+                "label": "enum_value_yes",
+                "value": false
+              },
+              {
+                "label": "enum_value_no",
+                "value": true
+              }
+            ]
           },
           {
             "name": "private_browsing",
@@ -3342,20 +3355,6 @@
       {
         "label": "enum_value_no",
         "value": false
-      }
-    ],
-    "boolean_inverted_optional": [
-      {
-        "label": "enum_value_no_preference",
-        "value": null
-      },
-      {
-        "label": "enum_value_yes",
-        "value": false
-      },
-      {
-        "label": "enum_value_no",
-        "value": true
       }
     ],
     "enable": [

--- a/src/policies/firefox.json
+++ b/src/policies/firefox.json
@@ -752,7 +752,7 @@
             "name": "updates_disabled",
             "label": "policy_description_ExtensionSettings_updates_disabled",
             "schema": "enum",
-            "preset": "boolean_optional"
+            "preset": "boolean_inverted_optional"
           },
           {
             "name": "private_browsing",
@@ -3342,6 +3342,20 @@
       {
         "label": "enum_value_no",
         "value": false
+      }
+    ],
+    "boolean_inverted_optional": [
+      {
+        "label": "enum_value_no_preference",
+        "value": null
+      },
+      {
+        "label": "enum_value_yes",
+        "value": false
+      },
+      {
+        "label": "enum_value_no",
+        "value": true
       }
     ],
     "enable": [


### PR DESCRIPTION
## Summary

Closes #379. The `updates_disabled` option in `ExtensionSettings` is shown to the user as **Allow automatic updates** but emits the boolean to a Firefox field whose name has the opposite meaning (`updates_disabled: true` blocks updates). In 8.0 it was wired to the plain `boolean_optional` preset, so user → emitted bool was a straight 1:1 mapping — picking "Yes" (allow updates) wrote `updates_disabled: true` to `policies.json` and disabled updates.

## Fix

Added a `boolean_inverted_optional` preset that mirrors the existing `enable_inverted_optional` pattern: same Yes/No labels (so no translation churn across the 30+ locales), but with `value: false` for Yes and `value: true` for No. Pointed `updates_disabled` at it.

```json
"boolean_inverted_optional": [
  { "label": "enum_value_no_preference", "value": null },
  { "label": "enum_value_yes",           "value": false },
  { "label": "enum_value_no",            "value": true  }
]
```

```json
{
  "name": "updates_disabled",
  "label": "policy_description_ExtensionSettings_updates_disabled",
  "schema": "enum",
- "preset": "boolean_optional"
+ "preset": "boolean_inverted_optional"
}
```

This keeps the `enable_inverted_optional` pattern intact for everything else and only changes the emitted boolean for this one option.

## Test plan

- [x] `npx jsonschema validate policies-schema.json src/policies/firefox.json` — clean
- [x] `npm run lint:policies` — clean
- [x] Verified the resulting preset in `firefox.json` has `Yes → false`, `No → true` for `updates_disabled` (matches Firefox's policy semantics)

Closes #379