### PR TITLE
Add exclusion between download directory policies

### DIFF
--- a/src/policies/firefox.json
+++ b/src/policies/firefox.json
@@ -1121,6 +1121,7 @@
     "DefaultDownloadDirectory": {
       "availability": { "mainstream": "68.0", "esr": "68.0" },
       "tags": ["downloads"],
+      "exclude": ["DownloadDirectory"],
       "schema": "string",
       "placeholder": "policy_description_DefaultDownloadDirectory_Label",
       "validations": ["required"]
@@ -1128,6 +1129,7 @@
     "DownloadDirectory": {
       "availability": { "mainstream": "68.0", "esr": "68.0" },
       "tags": ["downloads"],
+      "exclude": ["DefaultDownloadDirectory"],
       "schema": "string",
       "placeholder": "policy_description_DownloadDirectory_Label",
       "validations": ["required"]


### PR DESCRIPTION
## Summary
- make DefaultDownloadDirectory exclude DownloadDirectory
- make DownloadDirectory exclude DefaultDownloadDirectory

Closes #391.

## Validation
- npm ci
- npm run lint:policies
- npm run lint:js
- npm run lint
- npm run build
- git diff --check

Note: `npm run lint` reports the existing web-ext Firefox Android manifest warning, with 0 errors and 0 notices.